### PR TITLE
Fix/flood extent

### DIFF
--- a/floodpipeline/extract.py
+++ b/floodpipeline/extract.py
@@ -18,7 +18,6 @@ import logging
 import glob 
 import numpy as np
 import xarray as xr
-from rasterio.transform import from_origin
 from rasterio.warp import calculate_default_transform, reproject, Resampling
 import hydromt_sfincs
 
@@ -432,27 +431,15 @@ class Extract:
 
             data = np.nan_to_num(flood_masked.values, nan=0.0)
 
-            # Use x and y coordinates
-            x = ds['x'].values
-            y = ds['y'].values
-
-            # Ensure y is in descending order (top-to-bottom)
-            if y[0] < y[-1]:
-                y = y[::-1]
-                data = data[::-1, :]
-
-            # Calculate resolution
-            res_x = (x[-1] - x[0]) / (len(x) - 1)
-            res_y = (y[0] - y[-1]) / (len(y) - 1)
-
-            # Define transform and CRS
-            src_transform = from_origin(x[0], y[0], res_x, res_y)
-            src_crs = 'EPSG:32637'
+            # Use georeferencing from the downscaled raster itself so bounds and shape stay consistent.
+            src_transform = flood_masked.rio.transform(recalc=True)
+            src_crs = flood_masked.rio.crs or 'EPSG:32637'
             dst_crs = 'EPSG:4326'
 
             # Prepare destination transform and shape
+            src_bounds = rasterio.transform.array_bounds(data.shape[0], data.shape[1], src_transform)
             dst_transform, width, height = calculate_default_transform(
-                src_crs, dst_crs, data.shape[1], data.shape[0], *rasterio.transform.array_bounds(data.shape[0], data.shape[1], src_transform)
+                src_crs, dst_crs, data.shape[1], data.shape[0], *src_bounds
             )
 
             # Prepare output array

--- a/floodpipeline/forecast.py
+++ b/floodpipeline/forecast.py
@@ -274,32 +274,17 @@ class Forecast:
 
     def __compute_flood_extent(self):
         """Compute flood extent raster"""
-        # get country-wide flood extent rasters
-        country = self.data.forecast_admin.country
-        flood_rasters = {}
-        output_dir = self.input_data_path+'/hydrology'
+        adm_lvl = self.data.forecast_admin.adm_levels[-1]
 
-        # Loop through return periods and copy the file 
-        # Here we are going to use a floodextent map developed for the actual event but keepinng the retun period logic 
-        # please replace this as it might not be needed
-        for rp in [5, 10, 20, 50, 75, 100, 200, 500]:
-            output_filename = f"flood_map_{country.upper()}_RP{rp}.tif"
-            output_path = os.path.join(output_dir, output_filename)
-            shutil.copyfile(self.flood_extent_raster, output_path)
-
-            flood_rasters[rp] = output_path
-
-        # create empty raster
+        # create empty raster from the flood extent produced by prepare_wflow_data
         empty_raster = self.flood_extent_raster.replace(".tif", "_empty.tif")
-        with rasterio.open(list(flood_rasters.values())[0]) as src:
+        with rasterio.open(self.flood_extent_raster) as src:
             flood_raster_data = src.read()
             flood_raster_data = np.empty(flood_raster_data.shape)
             flood_raster_meta = src.meta.copy()
             flood_raster_meta["compress"] = "lzw"
             with rasterio.open(empty_raster, "w", **flood_raster_meta) as dest:
                 dest.write(flood_raster_data)
-
-        adm_lvl = self.data.forecast_admin.adm_levels[-1]
 
         # get adm boundaries
         gdf_adm = self.load.get_adm_boundaries(
@@ -317,15 +302,10 @@ class Forecast:
             ):
                 if forecast_data_unit.triggered:
                     adm_bounds = gdf_adm.loc[forecast_data_unit.pcode, "geometry"]
-                    rp = forecast_data_unit.return_period
 
-                    # if return period is not available, use the smallest available
-                    if rp not in flood_rasters.keys():
-                        rp = min(flood_rasters.keys())
-
-                    # clip flood extent raster with admin division boundaries
+                    # clip the flood extent raster with admin division boundaries
                     flood_raster_data, flood_raster_meta = clip_raster(
-                        flood_rasters[rp], [adm_bounds]
+                        self.flood_extent_raster, [adm_bounds]
                     )
                     # save the clipped raster
                     flood_raster_admin_div = (


### PR DESCRIPTION
This fix addresses issues with the incorrect flood extent posted to IBF:
- Remove the raster scaling in `extract` that makes output flood extent tif 10 times larger than its original extent
- Remove use of riverine flood raster files when calculating flood extent in `forecast`
- Use the flood extent produced by `extract` when calculating flood extent