### PR TITLE
Fix wflow filename pattern

### DIFF
--- a/floodpipeline/extract.py
+++ b/floodpipeline/extract.py
@@ -327,7 +327,7 @@ class Extract:
                         )   
                 logging.info("finished extracting rainfall data")
             else:
-                logging.error("No NetCDF file with 'Nowcast_rain' in the name found.")
+                logging.warning("No NetCDF file with 'Nowcast_rain' in the name found.")
 
 
     def prepare_wflow_data(self, country: str = None, debug: bool = False):

--- a/floodpipeline/load.py
+++ b/floodpipeline/load.py
@@ -306,7 +306,6 @@ class Load:
         try:
             ftps.cwd(folder_path)
             files = ftps.nlst()
-            print('files: ', files)
 
             if not files:
                 logging.warning("No files found in directory.")
@@ -323,7 +322,6 @@ class Load:
                 now_files = [f for f in files if "wflow" in f]
                 fname_annex=["floodmap","wflow"]
                 files_dict={"floodmap":obs_files,"wflow":now_files}
-                print('files_dict: ', files_dict)
             else:
                 logging.error("Correct directory should be specified to find files.")
                 return

--- a/floodpipeline/load.py
+++ b/floodpipeline/load.py
@@ -306,7 +306,6 @@ class Load:
         try:
             ftps.cwd(folder_path)
             files = ftps.nlst()
-            print('files: ', files)
 
             if not files:
                 logging.warning("No files found in directory.")
@@ -319,11 +318,10 @@ class Load:
                 fname_annex=["Observation_rain","Nowcast_rain"]
                 files_dict={"Observation_rain":obs_files,"Nowcast_rain":now_files}  
             elif base_dir=="Hydrology":
-                obs_files = [f for f in files if "floodmap" in f]
-                now_files = [f for f in files if "wflow" in f]
+                obs_files = [f for f in files if "floodmap" in f and "forecast" in f]
+                now_files = [f for f in files if "wflow" in f and "forecast" in f]
                 fname_annex=["floodmap","wflow"]
                 files_dict={"floodmap":obs_files,"wflow":now_files}
-                print('files_dict: ', files_dict)
             else:
                 logging.error("Correct directory should be specified to find files.")
                 return

--- a/floodpipeline/load.py
+++ b/floodpipeline/load.py
@@ -306,6 +306,7 @@ class Load:
         try:
             ftps.cwd(folder_path)
             files = ftps.nlst()
+            print('files: ', files)
 
             if not files:
                 logging.warning("No files found in directory.")
@@ -318,10 +319,11 @@ class Load:
                 fname_annex=["Observation_rain","Nowcast_rain"]
                 files_dict={"Observation_rain":obs_files,"Nowcast_rain":now_files}  
             elif base_dir=="Hydrology":
-                obs_files = [f for f in files if "floodmap" in f and "forecast" in f]
-                now_files = [f for f in files if "wflow" in f and "forecast" in f]
+                obs_files = [f for f in files if "floodmap" in f]
+                now_files = [f for f in files if "wflow" in f]
                 fname_annex=["floodmap","wflow"]
                 files_dict={"floodmap":obs_files,"wflow":now_files}
+                print('files_dict: ', files_dict)
             else:
                 logging.error("Correct directory should be specified to find files.")
                 return


### PR DESCRIPTION
- Remove `forecast` out of the wflow filename patterns as it is no longer used in the FTP server
- Switch logging to warning for `Meteorological` data as the data is no longer provided in the FTP server
- Minor cleanups